### PR TITLE
perf: set AuthStyleInParams.

### DIFF
--- a/withings/client.go
+++ b/withings/client.go
@@ -204,8 +204,9 @@ func GetNewConf(cid, secret, redirectURL string) oauth2.Config {
 		ClientSecret: secret,
 		Scopes:       []string{strings.Join([]string(scopes), ",")},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  authURL,
-			TokenURL: tokenURL,
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
 		},
 	}
 	return conf


### PR DESCRIPTION
default AuthStyle is AuthStyleAutoDetect.
but AuthStyleAutoDetect try both ways AuthStyleInHeader and AuthStyleInParams.
Withings API must be AuthStyleInParams.

see https://cs.opensource.google/go/x/oauth2/+/2bc19b11:internal/token.go;l=188-229;drc=2bc19b11175fd0ae72c59c53fa45eff3f93d6a46

thanks for useful library!